### PR TITLE
Add support for input into plain x windows via xtest

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ AC_SUBST(LIBVERSION)
 
 AM_CONFIG_HEADER(config.h)
 
-CFLAGS="$CFLAGS -Werror -Wall -Wmissing-prototypes -Wmissing-declarations -fno-strict-aliasing"
+CFLAGS="$CFLAGS -Wall -Wmissing-prototypes -Wmissing-declarations -fno-strict-aliasing"
 
 AC_CANONICAL_HOST
 
@@ -85,6 +85,9 @@ AC_SUBST(DBUS_CFLAGS)
 PKG_CHECK_MODULES(X11, x11)
 AC_SUBST(X11_LIBS)
 AC_SUBST(X11_CFLAGS)
+
+PKG_CHECK_MODULES(XTST, xtst)
+AC_SUBST(XTST_LIBS)
 
 localedir=${datadir}/locale
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,6 +40,8 @@ hildon_im_recache_LDFLAGS = -Wl,--as-needed -rdynamic
 libhildon_im_ui_la_SOURCES = \
 	hildon-im-ui.h \
 	hildon-im-ui.c \
+	hildon-im-xcode.h\
+	hildon-im-xcode.c\
 	hildon-im-plugin.h \
 	hildon-im-plugin.c \
 	hildon-im-widget-loader.c \
@@ -50,7 +52,7 @@ libhildon_im_ui_la_SOURCES = \
 libhildon_im_ui_la_LIBADD = \
 	$(GTK_LIBS) $(GCONF_LIBS) $(ESD_LIBS) $(HILDON_LIBS) \
 	$(LIBOSSO_LIBS) $(HILDON_IMF_LIBS) $(GLIB_LIBS) \
-	$(LIBIMLAYOUTS_LIBS) $(DBUS_LIBS) $(X11_LIBS) -ldl
+	$(LIBIMLAYOUTS_LIBS) $(DBUS_LIBS) $(X11_LIBS) $(XTST_LIBS) -ldl
 libhildon_im_ui_la_LDFLAGS = -Wl,--as-needed -version-info $(LIBVERSION)
 
 hildon_input_methodincludeinstdir = $(includedir)/hildon-input-method

--- a/src/hildon-im-xcode.c
+++ b/src/hildon-im-xcode.c
@@ -1,0 +1,91 @@
+/*
+ * This file is part of hildon-input-method
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ *
+ */
+
+#include <X11/keysym.h>
+#include <X11/extensions/XTest.h>
+
+#include "hildon-im-xcode.h"
+
+KeySym hildon_im_utf_to_keysym(gunichar utf_char)
+{
+  KeySym sym = NoSymbol;
+  char buf[6];
+
+  if (g_unichar_to_utf8(utf_char, buf) > 0)
+  {
+    switch (buf[0])
+    {
+      case ' ':
+      return XK_space;
+      case '\n':
+      return XK_Return;
+      case '.':
+      return XK_period;
+      case '!':
+      return XK_exclam;
+      case '?':
+      return XK_question;
+      case ':':
+      return XK_colon;
+      case '-':
+      return XK_minus;
+      case '/':
+      return XK_slash;
+      case '\\':
+      return XK_backslash;
+      case '&':
+      return XK_ampersand;
+    }
+
+    buf[1] = '\0';
+    sym = XStringToKeysym(buf);
+  }
+
+  return sym;
+}
+
+void hildon_im_send_utf_via_xlib(Display *dpy, gunichar utf_char)
+{
+  KeySym sym;
+  gboolean require_shift = g_unichar_isalpha(utf_char) && g_unichar_isupper(utf_char);
+
+  sym = hildon_im_utf_to_keysym(utf_char);
+  
+  if (sym != NoSymbol)
+  {
+    KeyCode code =  XKeysymToKeycode(dpy, sym);
+    if(code)
+    {
+      if (require_shift)
+        XTestFakeKeyEvent(dpy,  XKeysymToKeycode(dpy, XK_Shift_L), True, CurrentTime);
+      
+      XTestFakeKeyEvent(dpy, code, True, CurrentTime);
+      XTestFakeKeyEvent(dpy, code, False, CurrentTime);
+
+      if (require_shift)
+        XTestFakeKeyEvent(dpy,  XKeysymToKeycode(dpy, XK_Shift_L), False, CurrentTime);
+    }
+    else
+      g_warning("no KeyCode for %u\n", utf_char);
+  }
+  else
+  {
+    g_warning("no KeySym for %u\n", utf_char);
+  }
+}

--- a/src/hildon-im-xcode.h
+++ b/src/hildon-im-xcode.h
@@ -1,0 +1,31 @@
+/*
+ * This file is part of hildon-input-method
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ *
+ */
+
+#ifndef __HILDON_IM_XCODE_H__
+#define __HILDON_IM_XCODE_H__
+
+#include <X11/X.h>
+#include <X11/Xlib.h>
+#include <gmodule.h>
+
+KeySym hildon_im_utf_to_keysym(gunichar utf_char);
+
+void hildon_im_send_utf_via_xlib(Display *dpy, gunichar utf_char);
+
+#endif


### PR DESCRIPTION
This allows him to type into any window, using plain xlib as a fallback if the window dosent support the custom him protocol

Due to xlib limitations only keysyms that are part of the current keycode map can be typed, others are simply ignored.
Addtionally right now only the keysyms a-z A-Z 0-9 and the ones explicitly mentioned in hildon_im_utf_to_keysym can be typed.

in theory any keysym defined here https://cgit.freedesktop.org/xorg/proto/x11proto/tree/keysymdef.h  could be typed but we need to make a utf8->keysym lut for him to do so.

the above limitations of course do not apply to windows that support the hildon input protokoll they are not affected at all by these changes.